### PR TITLE
Add path flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 
 ### Installation/Update:
 
+NOTE: SpotX does not support the Spotify client from Snap 
 - Close Spotify completely.
 - Run The following command in Terminal:
 
@@ -37,6 +38,7 @@ bash <(curl -sSL https://raw.githubusercontent.com/SpotX-CLI/SpotX-Linux/main/in
 `-c`  Clear app cache -- use if UI-related patches aren't working  
 `-e`  Experimental features -- enables experimental features  
 `-f`  Force patch -- forces re-patching if backup detected  
+`-P`  Path directory -- manually set Spotify directory if not found in PATH  
 `-p`  Premium subscription setup -- use if premium subscriber  
 
 Use any combination of flags.  


### PR DESCRIPTION
- add `-P` flag to manually set Spotify path
- add support for enabling write permissions in Spotify directory if write permissions are not found (thanks to @dabiathenord for the heads up and ideas)
- update readme for path flag and to note that Snap installs are not supported